### PR TITLE
Remove temporary OWSLib installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,6 @@ FROM apache/superset:5.0.0rc2@sha256:00c4ddf3b8a6a9fc95f0dffb09e8f29129732ca5fee
 
 USER root
 
-# Install git
-RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
-
 RUN /app/.venv/bin/python -m ensurepip --upgrade
 
 COPY superset_config.py /app/pythonpath/
@@ -16,12 +13,6 @@ RUN chmod +x /app/docker-entrypoint.sh
 # Install all dependencies to /app/pythonpath
 COPY requirements.txt /app/pythonpath
 RUN pip3 install --no-cache-dir -r /app/pythonpath/requirements.txt
-
-# Install OWSLib from GitHub (until official release is available)
-RUN pip3 install --no-cache-dir "git+https://github.com/geopython/OWSLib.git@master"
-
-# Clean up git again
-RUN apt-get purge -y git && apt-get autoremove -y && rm -rf /var/lib/apt/lists/*
 
 USER superset
 ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ The plugin can currently be installed via the test instance of the [Python Packa
 
 ```bash
 pip install -i https://test.pypi.org/simple/ superset-wfs-dialect
-pip install "git+https://github.com/geopython/OWSLib.git@master" # Necessary until an official release is available
 ```
 
 The dialect must then be registered in the the local `superset_config.py`:
@@ -39,10 +38,7 @@ For debugging and code completion run via terminal within the project root:
 python3 -m venv .venv
 source .venv/bin/activate
 pip install -e .
-pip install "git+https://github.com/geopython/OWSLib.git@master" # Necessary until an official release is available
 ```
-
-Please note, that you have to install OWSLib separately for now until there is a new version available.
 
 **or** create a virtual environment via VS Code:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests>=2.32.3
 sqlglot>=21.0.0
 debugpy>=1.8.14
 lxml>=5.4.0
+OWSLib>=0.34.0


### PR DESCRIPTION
This PR is a refactoring and removes temporary OWSLib installation (and git). Instead, the current official release has been added to `requirements.txt`