### PR TITLE
feat: get coverage and run SonarQube-scan

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,7 +53,7 @@ jobs:
 
     - name: Verify Coverage Report
       run: |
-        ls -l .
+        ls -l coverage.xml
     
     - name: Get version 
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,7 +53,7 @@ jobs:
 
     - name: Verify Coverage Report
       run: |
-        ls -l superset_wfs_dialect/coverage.xml
+        ls -l .
     
     - name: Get version 
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,21 +24,24 @@ jobs:
         python -m pip install --upgrade pip
         pip install -e .
         pip install "git+https://github.com/geopython/OWSLib.git@master"
-        pip install pytest pytest-cov
+        pip install pytest tox
 
-    - name: Run tests with coverage
+    - name: Run tests 
       run: |
         cd superset_wfs_dialect
-        pytest --cov=superset_wfs_dialect --cov-report=xml
+        pytest 
+
+    - name: Run tox
+      run: tox -e py
 
     - name: Upload Coverage Report
       uses: actions/upload-artifact@v4
       with:
-          name: coverage-report
-          path: superset_wfs_dialect/coverage.xml
+        name: coverage-report
+        path: coverage.xml
+  
 
   sonar:
-    needs: test
     runs-on: ubuntu-latest
       
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,12 @@ jobs:
         cd superset_wfs_dialect
         pytest --cov=superset_wfs_dialect --cov-report=xml
 
+    - name: Upload Coverage Report
+      uses: actions/upload-artifact@v3
+      with:
+          name: coverage-report
+          path: superset_wfs_dialect/coverage.xml
+
   sonar:
     needs: test
     runs-on: ubuntu-latest
@@ -39,6 +45,15 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+
+    - name: Download Coverage Report
+      uses: actions/download-artifact@v3
+      with:
+        name: coverage-report
+
+    - name: Verify Coverage Report
+      run: |
+        ls -l superset_wfs_dialect/coverage.xml
     
     - name: Get version 
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,8 +41,9 @@ jobs:
     - name: Install Sonar Scanner
       run: |
         curl -sSLo sonar-scanner.zip https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.8.0.2856-linux.zip
-        unzip sonar-scanner.zip -d $HOME
-        export PATH="$HOME/sonar-scanner-4.8.0.2856-linux/bin:$PATH"
+        unzip sonar-scanner.zip -d $HOME/sonar-scanner
+        echo "export PATH=$HOME/sonar-scanner/sonar-scanner-4.8.0.2856-linux/bin:$PATH" >> $HOME/.bashrc
+        source $HOME/.bashrc
       
     - name: Run SonarQube Scan
       env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,8 +1,8 @@
 name: Tests
 
 on:
-  push:
-    branches: [ main ]
+  push: 
+    branches: ['*']
   pull_request:
     branches: [ main ]
 
@@ -24,9 +24,33 @@ jobs:
         python -m pip install --upgrade pip
         pip install -e .
         pip install "git+https://github.com/geopython/OWSLib.git@master"
-        pip install pytest
+        pip install pytest pytest-cov
 
-    - name: Run tests
+    - name: Run tests with coverage
       run: |
         cd superset_wfs_dialect
-        pytest
+        pytest --cov=superset_wfs_dialect --cov-report=xml
+
+  sonar:
+    needs: test
+    runs-on: ubuntu-latest
+      
+    steps:
+    - uses: actions/checkout@v4
+      
+    - name: Install Sonar Scanner
+      run: |
+        curl -sSLo sonar-scanner.zip https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.8.0.2856-linux.zip
+        unzip sonar-scanner.zip -d $HOME
+        export PATH="$HOME/sonar-scanner-4.8.0.2856-linux/bin:$PATH"
+      
+    - name: Run SonarQube Scan
+      env:
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      run: |
+        sonar-scanner \
+          -Dsonar.projectKey=superset_wfs_dialect \
+          -Dsonar.sources=superset_wfs_dialect \
+          -Dsonar.tests=superset_wfs_dialect/tests \
+          -Dsonar.python.coverage.reportPaths=superset_wfs_dialect/coverage.xml \
+          -Dsonar.host.url=https://sq.terrestris.de

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,6 +42,7 @@ jobs:
   
 
   sonar:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: test
       

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,19 +19,7 @@ jobs:
       run: |
         apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -e .
-        pip install "git+https://github.com/geopython/OWSLib.git@master"
-        pip install pytest tox
-
-    - name: Run tests 
-      run: |
-        cd superset_wfs_dialect
-        pytest 
-
-    - name: Run tox
+    - name: Run tests with coverage
       run: tox -e py
 
     - name: Upload Coverage Report

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,6 +39,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+    
+    - name: Get version 
+      run: |
+        echo "sonar.projectVersion=$(git describe --tags --abbrev=0 | sed 's/^v//')" >> ./sonar-project.properties
       
     - name: Run SonarQube Scan
       uses: SonarSource/sonarqube-scan-action@v5.2.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,21 +37,11 @@ jobs:
       
     steps:
     - uses: actions/checkout@v4
-      
-    - name: Install Sonar Scanner
-      run: |
-        curl -sSLo sonar-scanner.zip https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.8.0.2856-linux.zip
-        unzip sonar-scanner.zip -d $HOME/sonar-scanner
-        echo "export PATH=$HOME/sonar-scanner/sonar-scanner-4.8.0.2856-linux/bin:$PATH" >> $HOME/.bashrc
-        source $HOME/.bashrc
+      with:
+        fetch-depth: 0
       
     - name: Run SonarQube Scan
+      uses: SonarSource/sonarqube-scan-action@v5.2.0
       env:
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      run: |
-        sonar-scanner \
-          -Dsonar.projectKey=superset_wfs_dialect \
-          -Dsonar.sources=superset_wfs_dialect \
-          -Dsonar.tests=superset_wfs_dialect/tests \
-          -Dsonar.python.coverage.reportPaths=superset_wfs_dialect/coverage.xml \
-          -Dsonar.host.url=https://sq.terrestris.de
+      

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,6 +43,7 @@ jobs:
 
   sonar:
     runs-on: ubuntu-latest
+    needs: test
       
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
         pip install -e .
         pip install "git+https://github.com/geopython/OWSLib.git@master"
         pip install tox
-        
+
     - name: Run tests with coverage
       run: tox -e py
 
@@ -63,4 +63,3 @@ jobs:
       uses: SonarSource/sonarqube-scan-action@v5.2.0
       env:
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,13 @@ jobs:
       run: |
         apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
 
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .
+        pip install "git+https://github.com/geopython/OWSLib.git@master"
+        pip install tox
+        
     - name: Run tests with coverage
       run: tox -e py
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
         pytest --cov=superset_wfs_dialect --cov-report=xml
 
     - name: Upload Coverage Report
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
           name: coverage-report
           path: superset_wfs_dialect/coverage.xml
@@ -47,7 +47,7 @@ jobs:
         fetch-depth: 0
 
     - name: Download Coverage Report
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: coverage-report
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,15 +15,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Install git (required for installing OWSLib from Git)
-      run: |
-        apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
-
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -e .
-        pip install "git+https://github.com/geopython/OWSLib.git@master"
         pip install tox
 
     - name: Run tests with coverage
@@ -63,3 +58,4 @@ jobs:
       uses: SonarSource/sonarqube-scan-action@v5.2.0
       env:
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ venv
 build
 sql_log.csv
 dist
+coverage.xml

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build
 sql_log.csv
 dist
 coverage.xml
+.coverage

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+[![Coverage](https://sq.terrestris.de/api/project_badges/measure?project=superset_wfs_dialect&metric=coverage&token=sqb_88a5e9f0f1eba432a07a9cd20ae27a6c4337271a)](https://sq.terrestris.de/dashboard?id=superset_wfs_dialect)
+[![Reliability Rating](https://sq.terrestris.de/api/project_badges/measure?project=superset_wfs_dialect&metric=software_quality_reliability_rating&token=sqb_88a5e9f0f1eba432a07a9cd20ae27a6c4337271a)](https://sq.terrestris.de/dashboard?id=superset_wfs_dialect)
+[![Maintainability Rating](https://sq.terrestris.de/api/project_badges/measure?project=superset_wfs_dialect&metric=software_quality_maintainability_rating&token=sqb_88a5e9f0f1eba432a07a9cd20ae27a6c4337271a)](https://sq.terrestris.de/dashboard?id=superset_wfs_dialect)
+[![Security Rating](https://sq.terrestris.de/api/project_badges/measure?project=superset_wfs_dialect&metric=software_quality_security_rating&token=sqb_88a5e9f0f1eba432a07a9cd20ae27a6c4337271a)](https://sq.terrestris.de/dashboard?id=superset_wfs_dialect)
+
 # SQLAlchemy dialect for OGC WFS
 
 SQLAlchemy dialect for OGC WFS as a Superset plugin.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,5 @@
+sonar.tests=superset_wfs_dialect/tests
+sonar.sources=superset_wfs_dialect
+sonar.projectKey=superset_wfs_dialect
+sonar.python.coverage.reportPaths=superset_wfs_dialect/coverage.xml
+sonar.host.url=https://sq.terrestris.de

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
 sonar.sources.exclusions=superset_wfs_dialect/tests/**
 sonar.sources=superset_wfs_dialect
 sonar.projectKey=superset_wfs_dialect
-sonar.python.coverage.reportPaths=superset_wfs_dialect/coverage.xml
+sonar.python.coverage.reportPaths=coverage.xml
 sonar.host.url=https://sq.terrestris.de

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
 sonar.sources.exclusions=superset_wfs_dialect/tests/**
-sonar.tests=superset_wfs_dialect/tests/**
+sonar.tests=superset_wfs_dialect/tests
 sonar.sources=superset_wfs_dialect
 sonar.projectKey=superset_wfs_dialect
 sonar.python.coverage.reportPaths=superset_wfs_dialect/coverage.xml

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,4 @@
 sonar.sources.exclusions=superset_wfs_dialect/tests/**
-sonar.tests=superset_wfs_dialect/tests
 sonar.sources=superset_wfs_dialect
 sonar.projectKey=superset_wfs_dialect
 sonar.python.coverage.reportPaths=superset_wfs_dialect/coverage.xml

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
 sonar.sources.exclusions=superset_wfs_dialect/tests/**
-sonar.tests.inclusions=superset_wfs_dialect/tests/**
+sonar.tests=superset_wfs_dialect/tests/**
 sonar.sources=superset_wfs_dialect
 sonar.projectKey=superset_wfs_dialect
 sonar.python.coverage.reportPaths=superset_wfs_dialect/coverage.xml

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
-sonar.tests=superset_wfs_dialect/tests
 sonar.sources.exclusions=superset_wfs_dialect/tests/**
+sonar.tests.inclusions=superset_wfs_dialect/tests/**
 sonar.sources=superset_wfs_dialect
 sonar.projectKey=superset_wfs_dialect
 sonar.python.coverage.reportPaths=superset_wfs_dialect/coverage.xml

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,5 @@
 sonar.tests=superset_wfs_dialect/tests
+sonar.sources.exclusions=superset_wfs_dialect/tests/**
 sonar.sources=superset_wfs_dialect
 sonar.projectKey=superset_wfs_dialect
 sonar.python.coverage.reportPaths=superset_wfs_dialect/coverage.xml

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,14 @@
+[tox]
+envlist = py
+ 
+[testenv]
+deps =
+    pytest
+    pytest-cov
+    -rrequirements.txt
+commands = pytest --cov=superset_wfs_dialect --cov-report=xml --cov-config=tox.ini --cov-branch
+
+[coverage:run]
+relative_files = True
+source = superset_wfs_dialect/
+branch = True


### PR DESCRIPTION
This PR edits the tests.yml workflow to get test-coverage (using pytest-cov) and run a SonarQube scan.
The scan is run on every push to the main branch.
SonarQube-results are added to the README as status badges.