### PR TITLE
Fix get_features request params

### DIFF
--- a/superset_wfs_dialect/base.py
+++ b/superset_wfs_dialect/base.py
@@ -369,14 +369,18 @@ class Cursor:
 
         propertyname = None if filterXml and self.propertynames == ["*"] else self.propertynames
 
-        response: BytesIO = wfs.getfeature(
-            typename=typename,
-            maxfeatures=limit,
-            propertyname=propertyname,
-            filter=filterXml,
-            startindex=startindex,
-            method='POST' if filterXml else 'GET'
-        )
+        params = {
+            "typename": typename,
+            "maxfeatures": limit,
+            "startindex": startindex,
+            "method": "POST" if filterXml else "GET"
+        }
+        if filterXml:
+            params["filter"] = filterXml
+        else:
+            params["propertyname"] = propertyname
+
+        response: BytesIO = wfs.getfeature(**params)
 
         gmlparser = GMLParser(
             geometry_column=self.connection.wfs.get_schema(self.typename).get("geometry_column")


### PR DESCRIPTION
This PR fixes an error when querying the features through OWSLib. The combination of `propertyname` and `filter` led to problems. If a restriction is made using a filter anyway, the property `propertyname` can be omitted.