### PR TITLE
Handle Coordinates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ sqlglot>=21.0.0
 debugpy>=1.8.14
 lxml>=5.4.0
 OWSLib>=0.34.0
+pyproj>=3.7.1

--- a/superset_wfs_dialect/base.py
+++ b/superset_wfs_dialect/base.py
@@ -207,7 +207,7 @@ class Cursor:
 
         gmlparser = GMLParser(
             geometry_column=self.connection.wfs.get_schema(typename).get("geometry_column"),
-            srs_name=self.connection.wfs.contents[typename].crsOptions[0]
+            srs_name=str(self.connection.wfs.contents[typename].crsOptions[0])
         )
 
         limit = 10000

--- a/superset_wfs_dialect/base.py
+++ b/superset_wfs_dialect/base.py
@@ -205,6 +205,11 @@ class Cursor:
         # If we have an aggregation, we have to recursively call the WFS until all features are fetched
         # and then aggregate them in Python
 
+        gmlparser = GMLParser(
+            geometry_column=self.connection.wfs.get_schema(typename).get("geometry_column"),
+            srs_name=self.connection.wfs.contents[typename].crsOptions[0]
+        )
+
         limit = 10000
 
         # fetch as many features as possible with one request
@@ -227,6 +232,7 @@ class Cursor:
             logger.info("Fetching features from %s to %s", startindex, startindex + limit)
             return self._get_features(
                 typename=typename,
+                gmlparser=gmlparser,
                 limit=limit,
                 filterXml=filterXml,
                 startindex=startindex
@@ -416,10 +422,13 @@ class Cursor:
     def _get_features(
         self,
         typename: str,
+        gmlparser: GMLParser,
         limit: Optional[int] = None,
         filterXml: Optional[str] = None,
         startindex: Optional[int] = None,
     ) -> List[Dict[str, Any]]:
+        if gmlparser is None:
+            raise ValueError("A GMLParser instance must be provided.")
         wfs = self.connection.wfs
 
         propertyname = None if filterXml and self.propertynames == ["*"] else self.propertynames
@@ -436,10 +445,6 @@ class Cursor:
             params["propertyname"] = propertyname
 
         response: BytesIO = wfs.getfeature(**params)
-
-        gmlparser = GMLParser(
-            geometry_column=self.connection.wfs.get_schema(self.typename).get("geometry_column")
-        )
 
         try:
             xml_text = response.read().decode("utf-8")

--- a/superset_wfs_dialect/base.py
+++ b/superset_wfs_dialect/base.py
@@ -427,8 +427,6 @@ class Cursor:
         filterXml: Optional[str] = None,
         startindex: Optional[int] = None,
     ) -> List[Dict[str, Any]]:
-        if gmlparser is None:
-            raise ValueError("A GMLParser instance must be provided.")
         wfs = self.connection.wfs
 
         propertyname = None if filterXml and self.propertynames == ["*"] else self.propertynames

--- a/superset_wfs_dialect/gml_parser.py
+++ b/superset_wfs_dialect/gml_parser.py
@@ -31,7 +31,10 @@ class GMLParser:
                 self.x_index = 0
                 self.y_index = 1
         except Exception as e:
-            logger.warning(f"Error parsing SRS name '{self._srs_name}': {e}")
+            logger.warning(
+                f"Cannot identify CRS by name '{self._srs_name}'. "
+                f"Defaulting to 'easting'."
+            )
             self.x_index = 0
             self.y_index = 1
 
@@ -89,7 +92,7 @@ class GMLParser:
         """Parse a GML Point element into WKT format."""
         pos = elem.find('./gml:pos', {'gml': 'http://www.opengis.net/gml/3.2'})
         if pos is not None:
-            coords = list(pos.text.strip().split())
+            coords = pos.text.strip().split()
             return f"POINT({coords[self.x_index]} {coords[self.y_index]})"
         raise ValueError("Invalid Point format")
 
@@ -122,7 +125,7 @@ class GMLParser:
         ns = {'gml': 'http://www.opengis.net/gml/3.2'}
         points = []
         for point in elem.findall('.//gml:Point/gml:pos', ns):
-            coords = list(point.text.strip().split())
+            coords = point.text.strip().split()
             points.append(f"({coords[self.x_index]} {coords[self.y_index]})")
         return f"MULTIPOINT({', '.join(points)})"
 

--- a/superset_wfs_dialect/gml_parser.py
+++ b/superset_wfs_dialect/gml_parser.py
@@ -1,19 +1,34 @@
 from typing import List, Dict
 import xml.etree.ElementTree as ET
+from pyproj import CRS
 
 class GMLParser:
     """
     A class to parse GML (Geography Markup Language) data.
     """
 
-    def __init__(self, geometry_column: str):
+    def __init__(self, geometry_column: str, srs_name: str):
         """
         Initialize the GMLParser with the geometry column name.
 
         Args:
             geometry_column: The name of the geometry column
+            srs_name: The spatial reference system name
         """
         self._geometry_column = geometry_column
+        self._srs_name = srs_name if isinstance(srs_name, str) else str(srs_name)
+
+        try:
+            crs = CRS.from_user_input(self._srs_name)
+            if crs.is_geographic and crs.axis_info[0].direction in ["north"]:
+                self.x_index = 1
+                self.y_index = 0
+            else:
+                self.x_index = 0
+                self.y_index = 1
+        except Exception as e:
+            self.x_index = 0
+            self.y_index = 1
 
     def parse(self, xml_text: str) -> List[Dict[str, str]]:
         """Parse GML XML response into a list of feature dictionaries.
@@ -61,15 +76,16 @@ class GMLParser:
         coords = pos_text.strip().split()
         coord_pairs = []
         for i in range(0, len(coords), 2):
-            coord_pairs.append(f"{coords[i]} {coords[i+1]}")
+            pair = (coords[i], coords[i+1])
+            coord_pairs.append(f"{pair[self.x_index]} {pair[self.y_index]}")
         return ", ".join(coord_pairs)
 
     def _parse_point(self, elem):
         """Parse a GML Point element into WKT format."""
         pos = elem.find('./gml:pos', {'gml': 'http://www.opengis.net/gml/3.2'})
         if pos is not None:
-            coords = pos.text.strip()
-            return f"POINT({coords})"
+            coords = list(map(float, pos.text.strip().split()))
+            return f"POINT({coords[self.x_index]} {coords[self.y_index]})"
         raise ValueError("Invalid Point format")
 
     def _parse_linestring(self, elem):
@@ -101,7 +117,8 @@ class GMLParser:
         ns = {'gml': 'http://www.opengis.net/gml/3.2'}
         points = []
         for point in elem.findall('.//gml:Point/gml:pos', ns):
-            points.append(f"({point.text.strip()})")
+            coords = list(map(float, point.text.strip().split()))
+            points.append(f"({coords[self.x_index]} {coords[self.y_index]})")
         return f"MULTIPOINT({', '.join(points)})"
 
     def _parse_multilinestring(self, elem):

--- a/superset_wfs_dialect/tests/test_gml_parser.py
+++ b/superset_wfs_dialect/tests/test_gml_parser.py
@@ -4,7 +4,8 @@ import xml.etree.ElementTree as ET
 
 class TestGMLParser(unittest.TestCase):
     def setUp(self):
-        self.parser = GMLParser("geom")
+        self.parser = GMLParser("geom", "urn:ogc:def:crs:EPSG::25833")
+        self.parser4258 = GMLParser("geom", "urn:ogc:def:crs:EPSG::4258")
         self.ns = {
             'gml': 'http://www.opengis.net/gml/3.2',
             'wfs': 'http://www.opengis.net/wfs/2.0'
@@ -132,6 +133,52 @@ class TestGMLParser(unittest.TestCase):
                   "((316416.4879 5691609.2954, 316810.3008 5691696.1469, " \
                   "316810.3008 5691609.2954, 316416.4879 5691609.2954)))"
         self.assertEqual(self.parser._gml_to_wkt(gml_elem), expected)
+
+    def test_point_epsg25833_axis_order(self):
+        gml = '''
+            <gml:Point xmlns:gml="http://www.opengis.net/gml/3.2" srsName="urn:ogc:def:crs:EPSG::25833" srsDimension="2">
+                <gml:pos>316316.4879 5691509.2954</gml:pos>
+            </gml:Point>
+        '''
+        gml_elem = ET.fromstring(gml)
+        expected = "SRID=25833;POINT(316316.4879 5691509.2954)"
+        self.assertEqual(self.parser._gml_to_wkt(gml_elem), expected)
+
+    def test_point_epsg4258_axis_order(self):
+        gml = '''
+            <gml:Point xmlns:gml="http://www.opengis.net/gml/3.2" srsName="urn:ogc:def:crs:EPSG::4258" srsDimension="2">
+                <gml:pos>50.93 6.95</gml:pos>
+            </gml:Point>
+        '''
+        gml_elem = ET.fromstring(gml)
+        expected = "SRID=4258;POINT(6.95 50.93)"
+        self.assertEqual(self.parser4258._gml_to_wkt(gml_elem), expected)
+
+    def test_linestring_epsg4258_axis_order(self):
+        gml = '''
+            <gml:LineString xmlns:gml="http://www.opengis.net/gml/3.2" srsName="urn:ogc:def:crs:EPSG::4258">
+                <gml:posList>50.93 6.95 51.00 7.00</gml:posList>
+            </gml:LineString>
+        '''
+        gml_elem = ET.fromstring(gml)
+        expected = "SRID=4258;LINESTRING(6.95 50.93, 7.00 51.00)"
+        self.assertEqual(self.parser4258._gml_to_wkt(gml_elem), expected)
+
+    def test_polygon_epsg4258_axis_order(self):
+        gml = '''
+            <gml:Polygon xmlns:gml="http://www.opengis.net/gml/3.2" srsName="urn:ogc:def:crs:EPSG::4258">
+                <gml:exterior>
+                    <gml:LinearRing>
+                        <gml:posList>
+                            50.0 6.0 51.0 6.0 51.0 7.0 50.0 7.0 50.0 6.0
+                        </gml:posList>
+                    </gml:LinearRing>
+                </gml:exterior>
+            </gml:Polygon>
+        '''
+        gml_elem = ET.fromstring(gml)
+        expected = "SRID=4258;POLYGON((6.0 50.0, 6.0 51.0, 7.0 51.0, 7.0 50.0, 6.0 50.0))"
+        self.assertEqual(self.parser4258._gml_to_wkt(gml_elem), expected)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR extends the `GMLParser` to handle axis order based on the provided spatial reference system (srs_name). This is especially important for geographic coordinate systems where axis order may differ from typical (X, Y) assumptions. To do this, `pyproj` is added as a new requirement.

Furthermore, the `GMLParser` is instantiated just once now in `_fetch_all_features` using the layer's `geometry_column` and declared `crsOptions[0]`  to improve performance.

The tests were extended to examine some of these cases.