### PR TITLE
Prevent division by zero in request calculation

### DIFF
--- a/superset_wfs_dialect/base.py
+++ b/superset_wfs_dialect/base.py
@@ -395,7 +395,7 @@ class Cursor:
                 limit = self._round_up_to_nearest_power(n=(total_features / 100))
 
         # Calculate the number of requests needed
-        num_requests = math.ceil(total_features / limit)
+        num_requests = math.ceil(total_features / limit) if limit > 0 else 1
         logger.debug("### Will make %s requests with limit %s", num_requests, limit)
 
         # If only one request is needed, fetch directly


### PR DESCRIPTION
Ensure that the number of requests defaults to one when the limit is zero, preventing potential division by zero errors.