### PR TITLE
Fix WFS 2.0.0 request typenames usage

### DIFF
--- a/superset_wfs_dialect/base.py
+++ b/superset_wfs_dialect/base.py
@@ -687,7 +687,7 @@ class Cursor:
         """
         base_url = self.connection.base_url
         # TODO: use self.connection.wfs.getfeature() !Does not support resultType!
-        url = f"{base_url}?SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&typename={typename}&resultType=hits"
+        url = f"{base_url}?SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&typenames={typename}&resultType=hits"
         logger.debug("### Filter XML: %s", filterXml)
         logger.debug("#### URL: %s", url)
         response = None


### PR DESCRIPTION
Update the WFS 2.0.0 request to use the correct plural form "typenames" instead of "typename" for compatibility with the specification.