### PR TITLE
Fix error to request with correct UTF-8 encoding/decoding

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,7 +20,7 @@
       "pathMappings": [
         {
           "localRoot": "${workspaceFolder}/superset_wfs_dialect",
-          "remoteRoot": "/app/pythonpath/superset_wfs_dialect"
+          "remoteRoot": "/app/superset_wfs_dialect/superset_wfs_dialect"
         }
       ],
       "justMyCode": false

--- a/README.md
+++ b/README.md
@@ -67,6 +67,42 @@ Start superset with the registered plugin:
 docker compose up -d --build
 ```
 
+### Integrate with a local Superset checkout (editable mode)
+
+If you are developing this dialect together with a local Superset checkout,
+use an editable install inside the Superset container so code changes in this
+repository are picked up immediately.
+
+- Superset is checked out in a sibling directory, e.g.
+  - `../superset`
+  - `../superset_wfs_dialect`
+- Superset is started via Docker Compose in development mode
+
+In the Superset checkout:
+
+1. Mount this repository into the Superset containers (e.g. `/app/superset_wfs_dialect`).
+1. Add this line to `docker/requirements-local.txt`:
+
+   ```txt
+   -e /app/superset_wfs_dialect
+   ```
+
+1. Register the dialect in `docker/pythonpath_dev/superset_config_docker.py`:
+
+   ```python
+   from sqlalchemy.dialects import registry
+   registry.register("wfs", "superset_wfs_dialect.dialect", "WfsDialect")
+   ```
+
+1. Set the `DEBUGGER` env variable for the superset service in superset/docker-compose.yml to `"1"` to enable debugging in the container.
+1. Restart the relevant services, for example:
+
+   ```bash
+   docker compose restart superset superset-worker superset-worker-beat
+   ```
+
+After restart, connect a database in Superset using a `wfs://...` SQLAlchemy URI as described above.
+
 ### Debugging during development
 
 Debugging can be activated via the VS Code during development using `F5`.
@@ -104,14 +140,12 @@ http://localhost:8088/
    ```
 
    This will:
-
    - Update the `version` field in `setup.py`
    - Commit the change to `main`
    - Create a Git tag e.g. `0.0.1`
    - Push the tag to GitHub
 
 2. The GitHub Actions workflow will be triggered by the tag:
-
    - It will build the package
    - Upload it to PyPI
 

--- a/superset_wfs_dialect/base.py
+++ b/superset_wfs_dialect/base.py
@@ -25,7 +25,8 @@ from owslib.fes2 import (
     PropertyIsNull,
 )
 from owslib.feature.wfs200 import WebFeatureService_2_0_0
-from owslib.util import openURL, Authentication
+from owslib.util import Authentication
+from .custom_open_url import openURL
 
 # from .wkt_parser import WKTParser
 from .sql_logger import SQLLogger
@@ -831,7 +832,7 @@ class Cursor:
             if queryElement is None:
                 raise ValueError("Failed to find Query element in GetFeature request")
             queryElement.set("srsName", "EPSG:4326")
-            data = ET.tostring(root, encoding="utf-8").decode("utf-8")
+            data = ET.tostring(root, encoding="utf-8")
             response = openURL(url, data, "POST")
         else:
             params["srsname"] = "EPSG:4326"

--- a/superset_wfs_dialect/custom_open_url.py
+++ b/superset_wfs_dialect/custom_open_url.py
@@ -1,0 +1,100 @@
+import requests
+
+from owslib.etree import etree, ParseError
+from owslib.util import Authentication, ServiceException, ResponseWrapper
+
+### Custom patch for owslib.util.openURL to set the Content-Type header for WFS POST to
+### text/xml; charset=utf-8. As soon as this is fixed in owslib, this file can be removed and the
+### original openURL can be used instead.
+def openURL(url_base, data=None, method='Get', cookies=None, username=None, password=None, timeout=30, headers=None,
+            verify=True, cert=None, auth=None):
+    """
+    Function to open URLs.
+
+    Uses requests library but with additional checks for OGC service exceptions and url formatting.
+    Also handles cookies and simple user password authentication.
+
+    :param headers: (optional) Dictionary of HTTP Headers to send with the :class:`Request`.
+    :param verify: (optional) whether the SSL cert will be verified. A CA_BUNDLE path can also be provided.
+                   Defaults to ``True``.
+    :param cert: (optional) A file with a client side certificate for SSL authentication
+                 to send with the :class:`Request`.
+    :param auth: Instance of owslib.util.Authentication
+    """
+
+    headers = headers if headers is not None else {}
+    rkwargs = {}
+
+    rkwargs['timeout'] = timeout
+
+    if auth:
+        if username:
+            auth.username = username
+        if password:
+            auth.password = password
+        if cert:
+            auth.cert = cert
+        verify = verify and auth.verify
+    else:
+        auth = Authentication(username, password, cert, verify)
+
+    if auth.username and auth.password:
+        rkwargs['auth'] = (auth.username, auth.password)
+    elif auth.auth_delegate is not None:
+        rkwargs['auth'] = auth.auth_delegate
+
+    rkwargs['cert'] = auth.cert
+    rkwargs['verify'] = verify
+
+    # FIXUP for WFS in particular, remove xml style namespace
+    # @TODO does this belong here?
+    method = method.split("}")[-1]
+
+    if method.lower() == 'post':
+        try:
+            etree.fromstring(data)
+            headers['Content-Type'] = 'text/xml; charset=utf-8'
+        except (ParseError, UnicodeEncodeError):
+            pass
+
+        rkwargs['data'] = data
+
+    elif method.lower() == 'get':
+        rkwargs['params'] = data
+
+    else:
+        raise ValueError("Unknown method ('%s'), expected 'get' or 'post'" % method)
+
+    if cookies is not None:
+        rkwargs['cookies'] = cookies
+
+    req = requests.request(method.upper(), url_base, headers=headers, **rkwargs)
+
+    if req.status_code == 400:
+        raise ServiceException(req.text)
+
+    if req.status_code in [401, 403, 404, 500, 502, 503, 504]:    # add more if needed
+        req.raise_for_status()
+
+    # check for service exceptions without the http header set
+    if 'Content-Type' in req.headers and \
+            req.headers['Content-Type'] in ['text/xml', 'application/xml', 'application/vnd.ogc.se_xml']:
+        # just in case 400 headers were not set, going to have to read the xml to see if it's an exception report.
+        se_tree = etree.fromstring(req.content)
+
+        # to handle the variety of namespaces and terms across services
+        # and versions, especially for "legacy" responses like WMS 1.3.0
+        possible_errors = [
+            '{http://www.opengis.net/ows}Exception',
+            '{http://www.opengis.net/ows/1.1}Exception',
+            '{http://www.opengis.net/ogc}ServiceException',
+            'ServiceException'
+        ]
+
+        for possible_error in possible_errors:
+            serviceException = se_tree.find(possible_error)
+            if serviceException is not None:
+                # and we need to deal with some message nesting
+                raise ServiceException('\n'.join([t.strip() for t in serviceException.itertext() if t.strip()]))
+
+    return ResponseWrapper(req)

--- a/superset_wfs_dialect/dialect.py
+++ b/superset_wfs_dialect/dialect.py
@@ -1,8 +1,7 @@
 from sqlalchemy.engine.default import DefaultDialect
 from sqlalchemy import types as sqltypes
 from sqlalchemy.dialects import registry
-from .base import FakeDbApi, GEOMETRY_COLUMN_NAME
-import superset_wfs_dialect
+from .base import GEOMETRY_COLUMN_NAME, dbapi as wfs_dbapi
 import logging
 
 logging.basicConfig(level=logging.INFO)
@@ -51,11 +50,11 @@ class WfsDialect(DefaultDialect):
 
     @classmethod
     def dbapi(cls):
-        return superset_wfs_dialect
+        return wfs_dbapi
 
     @classmethod
     def import_dbapi(cls):
-        return FakeDbApi
+        return wfs_dbapi
 
     # TODO use GetCapabilites & DescribeFeatureType
     def get_schema_names(self, connection, **kw):


### PR DESCRIPTION
This PR fixes issues in superset_wfs_dialect that caused errors in superset when loading and cross-filtering charts.  

- `WfsDialect.dbapi()` and `WfsDialect.import_dbapi()` now return the concrete `wfs_dbapi `object from `base.py` and avoid errors like module `'superset_wfs_dialect' has no attribute 'paramstyle'`
- filtered POST GetFeature requests now explicit UTF-8 payload so that cross-filter values containing special characters (e.g. Einschr**ä**nkungen, Fu**ß**g**ä**ngerverkehr) are transmitted correctly and no longer produce empty results. This fixes #52 (46a0ca11bb6bc728131062c88d6533fb51e9b475).

In addition, the README file will be updated to include instructions for integrating the dialect module into a superset development environment (372ded3a3a1df8503c30bb2041312cbfa9e4c93d).