### PR TITLE
Enhance filter handling for OR expressions and simplify null cases

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,21 +1,29 @@
 {
-    "version": "0.2.0",
-    "configurations": [
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Python Debugger: run_it",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "run_it.py",
+      "console": "integratedTerminal",
+      "args": "${command:pickArgs}"
+    },
+    {
+      "name": "Python: Remote Attach",
+      "type": "debugpy",
+      "request": "attach",
+      "connect": {
+        "host": "localhost",
+        "port": 5678
+      },
+      "pathMappings": [
         {
-            "name": "Python: Remote Attach",
-            "type": "debugpy",
-            "request": "attach",
-            "connect": {
-                "host": "localhost",
-                "port": 5678
-            },
-            "pathMappings": [
-                {
-                    "localRoot": "${workspaceFolder}/superset_wfs_dialect",
-                    "remoteRoot": "/app/pythonpath/superset_wfs_dialect"
-                }
-            ],
-            "justMyCode": false
+          "localRoot": "${workspaceFolder}/superset_wfs_dialect",
+          "remoteRoot": "/app/pythonpath/superset_wfs_dialect"
         }
-    ]
+      ],
+      "justMyCode": false
+    }
+  ]
 }

--- a/run_it.py
+++ b/run_it.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""
+Simple script to execute WFS dialect queries with parameterized URL and SQL.
+"""
+from superset_wfs_dialect import connect
+import argparse
+
+
+def execute_wfs_query(wfs_url, sql_query, username=None, password=None):
+  connection = connect(base_url=wfs_url, username=username, password=password)
+  cursor = connection.cursor()
+  cursor.execute(sql_query)
+  results = cursor.fetchall()
+  print(f'number of features: {len(results)}')
+
+
+def main():
+    """Main entry point with argument parsing."""
+    parser = argparse.ArgumentParser(
+        description="Execute SQL queries against a WFS service"
+    )
+    parser.add_argument(
+        "--url",
+        required=True,
+        help="WFS service URL (e.g., 'example.com/geoserver/ows')"
+    )
+    parser.add_argument(
+        "--sql",
+        required=True,
+        help="SQL query to execute (e.g., 'SELECT * FROM my_layer LIMIT 10')"
+    )
+    parser.add_argument(
+        "--username",
+        help="Username for BasicAuth (optional)"
+    )
+    parser.add_argument(
+        "--password",
+        help="Password for BasicAuth (optional)"
+    )
+    
+    args = parser.parse_args()
+    
+    # Execute the query
+    execute_wfs_query(
+        wfs_url=args.url,
+        sql_query=args.sql,
+        username=args.username,
+        password=args.password
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/superset_wfs_dialect/base.py
+++ b/superset_wfs_dialect/base.py
@@ -29,11 +29,46 @@ from owslib.util import openURL, Authentication
 
 # from .wkt_parser import WKTParser
 from .sql_logger import SQLLogger
+from .custom_literal_operator import CustomLiteralOperator
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 GEOMETRY_COLUMN_NAME = "geom"
+
+SUPPORTED_EXPRESSIONS = [
+    sqlglot.expressions.EQ,
+    sqlglot.expressions.NEQ,
+    sqlglot.expressions.GT,
+    sqlglot.expressions.GTE,
+    sqlglot.expressions.LT,
+    sqlglot.expressions.LTE,
+    sqlglot.expressions.And,
+    sqlglot.expressions.Or,
+    sqlglot.expressions.In,
+    sqlglot.expressions.Not,
+    sqlglot.expressions.Paren,
+    sqlglot.expressions.Like,
+    sqlglot.expressions.Is,
+]
+
+SQL_GLOT_FES_NAME_MAP = {
+    sqlglot.expressions.EQ: 'fes:PropertyIsEqualTo',
+    sqlglot.expressions.NEQ: 'fes:PropertyIsNotEqualTo',
+    sqlglot.expressions.GT : 'fes:PropertyIsGreaterThan',
+    sqlglot.expressions.GTE: 'fes:PropertyIsGreaterThanOrEqualTo',
+    sqlglot.expressions.LT: 'fes:PropertyIsLessThan',
+    sqlglot.expressions.LTE: 'fes:PropertyIsLessThanOrEqualTo',
+}
+
+SQL_GLOT_FES_MAP = {
+    sqlglot.expressions.EQ: PropertyIsEqualTo,
+    sqlglot.expressions.NEQ: PropertyIsNotEqualTo,
+    sqlglot.expressions.GT : PropertyIsGreaterThan,
+    sqlglot.expressions.GTE: PropertyIsGreaterThanOrEqualTo,
+    sqlglot.expressions.LT: PropertyIsLessThan,
+    sqlglot.expressions.LTE: PropertyIsLessThanOrEqualTo,
+}
 
 
 class Geometry(TypedDict):
@@ -886,26 +921,7 @@ class Cursor:
         :param is_root: Whether this is the root filter (should be wrapped in a Filter object)
         :return: An OWSLib Filter or related filter expression object
         """
-        expression = self._simplify_filter(expression)
-
-        supported_expressions = [
-            sqlglot.expressions.EQ,
-            sqlglot.expressions.NEQ,
-            sqlglot.expressions.GT,
-            sqlglot.expressions.GTE,
-            sqlglot.expressions.LT,
-            sqlglot.expressions.LTE,
-            sqlglot.expressions.And,
-            sqlglot.expressions.Or,
-            sqlglot.expressions.In,
-            sqlglot.expressions.Not,
-            sqlglot.expressions.Paren,
-            sqlglot.expressions.Like,
-            sqlglot.expressions.Is,
-            sqlglot.expressions.Boolean,
-        ]
-
-        if not isinstance(expression, tuple(supported_expressions)):
+        if not isinstance(expression, tuple(SUPPORTED_EXPRESSIONS)):
             raise ValueError(
                 "Unsupported filter expression:", expression.__class__.__name__
             )
@@ -923,6 +939,7 @@ class Cursor:
             )
 
         propertyname = expression.this.name
+        property_is_literal = isinstance(expression.this, sqlglot.expressions.Literal)
 
         if propertyname == GEOMETRY_COLUMN_NAME:
             raise ValueError("Geometry filters are not supported")
@@ -965,11 +982,11 @@ class Cursor:
         # Handle equality
         elif isinstance(expression, sqlglot.expressions.EQ):
             literal = expression.args["expression"].name
-            filter = PropertyIsEqualTo(propertyname=propertyname, literal=literal)
+            filter = self._custom_or_builtin_filter(propertyname, literal, sqlglot.expressions.EQ, property_is_literal)
         # Handle inequality
         elif isinstance(expression, sqlglot.expressions.NEQ):
             literal = expression.args["expression"].name
-            filter = PropertyIsNotEqualTo(propertyname=propertyname, literal=literal)
+            filter = self._custom_or_builtin_filter(propertyname, literal, sqlglot.expressions.NEQ, property_is_literal)
         # Handle LIKE
         elif isinstance(expression, sqlglot.expressions.Like):
             matchcase = False
@@ -985,37 +1002,42 @@ class Cursor:
         # Handle greater than
         elif isinstance(expression, sqlglot.expressions.GT):
             literal = expression.args["expression"].name
-            filter = PropertyIsGreaterThan(propertyname=propertyname, literal=literal)
+            filter = self._custom_or_builtin_filter(propertyname, literal, sqlglot.expressions.GT, property_is_literal)
         # Handle greater than or equal
         elif isinstance(expression, sqlglot.expressions.GTE):
             literal = expression.args["expression"].name
-            filter = PropertyIsGreaterThanOrEqualTo(
-                propertyname=propertyname, literal=literal
-            )
+            filter = self._custom_or_builtin_filter(propertyname, literal, sqlglot.expressions.GTE, property_is_literal)
         # Handle less than
         elif isinstance(expression, sqlglot.expressions.LT):
             literal = expression.args["expression"].name
-            filter = PropertyIsLessThan(propertyname=propertyname, literal=literal)
+            filter = self._custom_or_builtin_filter(propertyname, literal, sqlglot.expressions.LT, property_is_literal)
         # Handle less than or equal
         elif isinstance(expression, sqlglot.expressions.LTE):
             literal = expression.args["expression"].name
-            filter = PropertyIsLessThanOrEqualTo(
-                propertyname=propertyname, literal=literal
-            )
+            filter = self._custom_or_builtin_filter(propertyname, literal, sqlglot.expressions.LTE, property_is_literal)
         # Handle in
         elif isinstance(expression, sqlglot.expressions.In):
             literals = [lit.name for lit in expression.args["expressions"]]
-            if len(literals) == 1:
-                filter = PropertyIsEqualTo(
-                    propertyname=propertyname, literal=literals[0]
-                )
+            # In some cases, superset uses an `IN (NULL)` filter, which always evaluates to false in sql-where clauses. Since
+            # FES does not support this structure, we handle this by replacing it with an equivalent static filter that
+            # evaluates to false, i.e. `1 = 2`.
+            values = expression.args.get("expressions") or []
+            if values and all(
+                isinstance(value, sqlglot.expressions.Null) for value in values
+            ):
+                filter = CustomLiteralOperator(SQL_GLOT_FES_NAME_MAP[sqlglot.expressions.EQ], '1', '2')
             else:
-                # Combine multiple IN conditions with OR
-                subfilters = [
-                    PropertyIsEqualTo(propertyname=propertyname, literal=lit)
-                    for lit in literals
-                ]
-                filter = Or(subfilters)
+                if len(literals) == 1:
+                    filter = PropertyIsEqualTo(
+                        propertyname=propertyname, literal=literals[0]
+                    )
+                else:
+                    # Combine multiple IN conditions with OR
+                    subfilters = [
+                        PropertyIsEqualTo(propertyname=propertyname, literal=lit)
+                        for lit in literals
+                    ]
+                    filter = Or(subfilters)
         # Handle IS NULL
         elif isinstance(expression, sqlglot.expressions.Is):
             check_expr = expression.args["expression"]
@@ -1031,64 +1053,12 @@ class Cursor:
 
         return Filter(filter) if is_root else filter
 
-    def _simplify_filter(self, expression: Any) -> Any:
-        """
-        Superset can create patterns like `IN (NULL)` and `1 != 1` for empty
-        list filters. These can produce invalid WFS property references
-        (for example `ValueReference` = `1`) and lead to WFS errors.
-        This pre-processing reduces those special cases to boolean false and
-        simplifies surrounding AND/OR expressions accordingly.
 
-        :param expression: The sqlglot filter expression to simplify
-        :return: The simplified sqlglot expression
-        """
-        if isinstance(expression, sqlglot.expressions.Paren):
-            inner = self._simplify_filter(expression.this)
-            if isinstance(inner, sqlglot.expressions.Boolean):
-                return inner
-            return sqlglot.expressions.Paren(this=inner)
+    def _custom_or_builtin_filter(self, property_name, literal, operator_cls, property_is_literal):
+        if property_is_literal:
+            return CustomLiteralOperator(SQL_GLOT_FES_NAME_MAP[operator_cls], property_name, literal)
+        return SQL_GLOT_FES_MAP[operator_cls](propertyname=property_name, literal=literal)
 
-        if isinstance(expression, sqlglot.expressions.In):
-            values = expression.args.get("expressions") or []
-            if values and all(
-                isinstance(value, sqlglot.expressions.Null) for value in values
-            ):
-                return sqlglot.expressions.Boolean(this=False)
-            return expression
-
-        if isinstance(expression, sqlglot.expressions.NEQ):
-            left = expression.this
-            right = expression.args.get("expression")
-            if (
-                isinstance(left, sqlglot.expressions.Literal)
-                and isinstance(right, sqlglot.expressions.Literal)
-                and not left.is_string
-                and not right.is_string
-                and left.this == "1"
-                and right.this == "1"
-            ):
-                return sqlglot.expressions.Boolean(this=False)
-            return expression
-
-        if isinstance(expression, sqlglot.expressions.And):
-            left = self._simplify_filter(expression.this)
-            right = self._simplify_filter(expression.args["expression"])
-            if isinstance(left, sqlglot.expressions.Boolean) and left.this is False:
-                return left
-            if isinstance(right, sqlglot.expressions.Boolean) and right.this is False:
-                return right
-            return sqlglot.expressions.And(this=left, expression=right)
-
-        if isinstance(expression, sqlglot.expressions.Or):
-            left = self._simplify_filter(expression.this)
-            right = self._simplify_filter(expression.args["expression"])
-            if isinstance(left, sqlglot.expressions.Boolean) and left.this is False:
-                return right
-            if isinstance(right, sqlglot.expressions.Boolean) and right.this is False:
-                return left
-            return sqlglot.expressions.Or(this=left, expression=right)
-
-        return expression
 
     def _generate_description(self):
         """

--- a/superset_wfs_dialect/base.py
+++ b/superset_wfs_dialect/base.py
@@ -886,6 +886,8 @@ class Cursor:
         :param is_root: Whether this is the root filter (should be wrapped in a Filter object)
         :return: An OWSLib Filter or related filter expression object
         """
+        expression = self._simplify_filter(expression)
+
         supported_expressions = [
             sqlglot.expressions.EQ,
             sqlglot.expressions.NEQ,
@@ -894,11 +896,13 @@ class Cursor:
             sqlglot.expressions.LT,
             sqlglot.expressions.LTE,
             sqlglot.expressions.And,
+            sqlglot.expressions.Or,
             sqlglot.expressions.In,
             sqlglot.expressions.Not,
             sqlglot.expressions.Paren,
             sqlglot.expressions.Like,
             sqlglot.expressions.Is,
+            sqlglot.expressions.Boolean,
         ]
 
         if not isinstance(expression, tuple(supported_expressions)):
@@ -934,6 +938,16 @@ class Cursor:
         # Handle AND
         elif isinstance(expression, sqlglot.expressions.And):
             filter = And(
+                [
+                    self._get_filter_from_expression(expression.this, is_root=False),
+                    self._get_filter_from_expression(
+                        expression.args["expression"], is_root=False
+                    ),
+                ]
+            )
+        # Handle OR
+        elif isinstance(expression, sqlglot.expressions.Or):
+            filter = Or(
                 [
                     self._get_filter_from_expression(expression.this, is_root=False),
                     self._get_filter_from_expression(
@@ -1016,6 +1030,65 @@ class Cursor:
             raise ValueError("Unsupported filter expression")
 
         return Filter(filter) if is_root else filter
+
+    def _simplify_filter(self, expression: Any) -> Any:
+        """
+        Superset can create patterns like `IN (NULL)` and `1 != 1` for empty
+        list filters. These can produce invalid WFS property references
+        (for example `ValueReference` = `1`) and lead to WFS errors.
+        This pre-processing reduces those special cases to boolean false and
+        simplifies surrounding AND/OR expressions accordingly.
+
+        :param expression: The sqlglot filter expression to simplify
+        :return: The simplified sqlglot expression
+        """
+        if isinstance(expression, sqlglot.expressions.Paren):
+            inner = self._simplify_filter(expression.this)
+            if isinstance(inner, sqlglot.expressions.Boolean):
+                return inner
+            return sqlglot.expressions.Paren(this=inner)
+
+        if isinstance(expression, sqlglot.expressions.In):
+            values = expression.args.get("expressions") or []
+            if values and all(
+                isinstance(value, sqlglot.expressions.Null) for value in values
+            ):
+                return sqlglot.expressions.Boolean(this=False)
+            return expression
+
+        if isinstance(expression, sqlglot.expressions.NEQ):
+            left = expression.this
+            right = expression.args.get("expression")
+            if (
+                isinstance(left, sqlglot.expressions.Literal)
+                and isinstance(right, sqlglot.expressions.Literal)
+                and not left.is_string
+                and not right.is_string
+                and left.this == "1"
+                and right.this == "1"
+            ):
+                return sqlglot.expressions.Boolean(this=False)
+            return expression
+
+        if isinstance(expression, sqlglot.expressions.And):
+            left = self._simplify_filter(expression.this)
+            right = self._simplify_filter(expression.args["expression"])
+            if isinstance(left, sqlglot.expressions.Boolean) and left.this is False:
+                return left
+            if isinstance(right, sqlglot.expressions.Boolean) and right.this is False:
+                return right
+            return sqlglot.expressions.And(this=left, expression=right)
+
+        if isinstance(expression, sqlglot.expressions.Or):
+            left = self._simplify_filter(expression.this)
+            right = self._simplify_filter(expression.args["expression"])
+            if isinstance(left, sqlglot.expressions.Boolean) and left.this is False:
+                return right
+            if isinstance(right, sqlglot.expressions.Boolean) and right.this is False:
+                return left
+            return sqlglot.expressions.Or(this=left, expression=right)
+
+        return expression
 
     def _generate_description(self):
         """

--- a/superset_wfs_dialect/custom_literal_operator.py
+++ b/superset_wfs_dialect/custom_literal_operator.py
@@ -1,0 +1,17 @@
+from owslib.etree import etree
+from owslib import util
+from owslib.fes2 import OgcExpression, namespaces
+
+# Simple class that patches the issue of OWSLib not supporting
+# left-hand side literals in filters.
+class CustomLiteralOperator(OgcExpression):
+    def __init__(self, propertyoperator, leftSide, rightSide):
+        self.propertyoperator = propertyoperator
+        self.leftSide = leftSide
+        self.rightSide = rightSide
+
+    def toXML(self):
+        node0 = etree.Element(util.nspath_eval(self.propertyoperator, namespaces))
+        etree.SubElement(node0, util.nspath_eval('fes:Literal', namespaces)).text = self.leftSide
+        etree.SubElement(node0, util.nspath_eval('fes:Literal', namespaces)).text = self.rightSide
+        return node0

--- a/superset_wfs_dialect/tests/test_get_filter_from_expression.py
+++ b/superset_wfs_dialect/tests/test_get_filter_from_expression.py
@@ -13,6 +13,7 @@ from owslib.fes2 import (
     PropertyIsLessThan,
     PropertyIsLike,
     PropertyIsNotEqualTo,
+    PropertyIsNull,
 )
 
 
@@ -130,6 +131,44 @@ class TestGetFilterFromExpression(unittest.TestCase):
         self.assertIsInstance(filter_result.filter.operations[0], PropertyIsEqualTo)
         self.assertEqual(filter_result.filter.operations[0].propertyname, "column")
         self.assertEqual(filter_result.filter.operations[0].literal, "value")
+
+    def test_or_filter(self):
+        expression = sqlglot.parse_one("column1 = 'value1' OR column2 = 'value2'")
+        filter_result = self.cursor._get_filter_from_expression(expression)
+        self.assertIsInstance(filter_result, Filter)
+        self.assertIsInstance(filter_result.filter, Or)
+        self.assertEqual(len(filter_result.filter.operations), 2)
+        self.assertIsInstance(filter_result.filter.operations[0], PropertyIsEqualTo)
+        self.assertEqual(filter_result.filter.operations[0].propertyname, "column1")
+        self.assertEqual(filter_result.filter.operations[0].literal, "value1")
+        self.assertIsInstance(filter_result.filter.operations[1], PropertyIsEqualTo)
+        self.assertEqual(filter_result.filter.operations[1].propertyname, "column2")
+        self.assertEqual(filter_result.filter.operations[1].literal, "value2")
+
+    def test_crossfilter_null_or_expression(self):
+        expression = sqlglot.parse_one(
+            "sperrart IS NULL OR sperrart IN (NULL) AND (1 != 1)"
+        )
+        filter_result = self.cursor._get_filter_from_expression(expression)
+        self.assertIsInstance(filter_result, Filter)
+        self.assertIsInstance(filter_result.filter, PropertyIsNull)
+        self.assertEqual(filter_result.filter.propertyname, "sperrart")
+
+    def test_in_null_simplified_to_false_in_or(self):
+        expression = sqlglot.parse_one("column = 'value' OR column IN (NULL)")
+        filter_result = self.cursor._get_filter_from_expression(expression)
+        self.assertIsInstance(filter_result, Filter)
+        self.assertIsInstance(filter_result.filter, PropertyIsEqualTo)
+        self.assertEqual(filter_result.filter.propertyname, "column")
+        self.assertEqual(filter_result.filter.literal, "value")
+
+    def test_one_neq_one_simplified_to_false_in_or(self):
+        expression = sqlglot.parse_one("column = 'value' OR (1 != 1)")
+        filter_result = self.cursor._get_filter_from_expression(expression)
+        self.assertIsInstance(filter_result, Filter)
+        self.assertIsInstance(filter_result.filter, PropertyIsEqualTo)
+        self.assertEqual(filter_result.filter.propertyname, "column")
+        self.assertEqual(filter_result.filter.literal, "value")
 
 
 if __name__ == "__main__":

--- a/superset_wfs_dialect/tests/test_get_filter_from_expression.py
+++ b/superset_wfs_dialect/tests/test_get_filter_from_expression.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest.mock import MagicMock, patch
 from superset_wfs_dialect.base import Cursor, Connection
+from superset_wfs_dialect.custom_literal_operator import CustomLiteralOperator
 from .conftest import create_mock_wfs_instance
 import sqlglot
 from owslib.fes2 import (
@@ -53,6 +54,15 @@ class TestGetFilterFromExpression(unittest.TestCase):
         self.assertEqual(filter_result.filter.propertyname, "column")
         self.assertEqual(filter_result.filter.literal, "value")
 
+    def test_all_literals_equality_filter(self):
+        expression = sqlglot.parse_one("1 = 2")
+        filter_result = self.cursor._get_filter_from_expression(expression)
+        self.assertIsInstance(filter_result, Filter)
+        self.assertIsInstance(filter_result.filter, CustomLiteralOperator)
+        self.assertEqual(filter_result.filter.propertyoperator, "fes:PropertyIsEqualTo")
+        self.assertEqual(filter_result.filter.leftSide, "1")
+        self.assertEqual(filter_result.filter.rightSide, "2")
+
     def test_inequality_filter(self):
         expression = sqlglot.parse_one("column != 'value'")
         filter_result = self.cursor._get_filter_from_expression(expression)
@@ -90,6 +100,14 @@ class TestGetFilterFromExpression(unittest.TestCase):
         self.assertIsInstance(subfilters[1], PropertyIsEqualTo)
         self.assertEqual(subfilters[1].propertyname, "column")
         self.assertEqual(subfilters[1].literal, "value2")
+
+    def test_in_null_filter(self):
+        expression = sqlglot.parse_one("column IN (null)")
+        filter_result = self.cursor._get_filter_from_expression(expression)
+        self.assertIsInstance(filter_result.filter, CustomLiteralOperator)
+        self.assertEqual(filter_result.filter.propertyoperator, "fes:PropertyIsEqualTo")
+        self.assertEqual(filter_result.filter.leftSide, "1")
+        self.assertEqual(filter_result.filter.rightSide, "2")
 
     def test_like_filter_case_sensitive(self):
         expression = sqlglot.parse_one("column LIKE 'value%'")
@@ -145,30 +163,37 @@ class TestGetFilterFromExpression(unittest.TestCase):
         self.assertEqual(filter_result.filter.operations[1].propertyname, "column2")
         self.assertEqual(filter_result.filter.operations[1].literal, "value2")
 
+    def test_is_null_filter(self):
+        expression = sqlglot.parse_one("sperrart IS NULL")
+        filter_result = self.cursor._get_filter_from_expression(expression)
+        self.assertIsInstance(filter_result, Filter)
+        self.assertIsInstance(filter_result.filter, PropertyIsNull)
+        self.assertEqual(filter_result.filter.propertyname, "sperrart")
+
     def test_crossfilter_null_or_expression(self):
         expression = sqlglot.parse_one(
             "sperrart IS NULL OR sperrart IN (NULL) AND (1 != 1)"
         )
         filter_result = self.cursor._get_filter_from_expression(expression)
         self.assertIsInstance(filter_result, Filter)
-        self.assertIsInstance(filter_result.filter, PropertyIsNull)
-        self.assertEqual(filter_result.filter.propertyname, "sperrart")
+        self.assertIsInstance(filter_result.filter, Or)
+        self.assertEqual(len(filter_result.filter.operations), 2)
 
-    def test_in_null_simplified_to_false_in_or(self):
-        expression = sqlglot.parse_one("column = 'value' OR column IN (NULL)")
-        filter_result = self.cursor._get_filter_from_expression(expression)
-        self.assertIsInstance(filter_result, Filter)
-        self.assertIsInstance(filter_result.filter, PropertyIsEqualTo)
-        self.assertEqual(filter_result.filter.propertyname, "column")
-        self.assertEqual(filter_result.filter.literal, "value")
+        self.assertIsInstance(filter_result.filter.operations[0], PropertyIsNull)
+        self.assertEqual(filter_result.filter.operations[0].propertyname, "sperrart")
 
-    def test_one_neq_one_simplified_to_false_in_or(self):
-        expression = sqlglot.parse_one("column = 'value' OR (1 != 1)")
-        filter_result = self.cursor._get_filter_from_expression(expression)
-        self.assertIsInstance(filter_result, Filter)
-        self.assertIsInstance(filter_result.filter, PropertyIsEqualTo)
-        self.assertEqual(filter_result.filter.propertyname, "column")
-        self.assertEqual(filter_result.filter.literal, "value")
+        self.assertIsInstance(filter_result.filter.operations[1], And)
+        self.assertEqual(len(filter_result.filter.operations[1].operations), 2)
+
+        self.assertIsInstance(filter_result.filter.operations[1].operations[0], CustomLiteralOperator)
+        self.assertEqual(filter_result.filter.operations[1].operations[0].propertyoperator, "fes:PropertyIsEqualTo")
+        self.assertEqual(filter_result.filter.operations[1].operations[0].leftSide, "1")
+        self.assertEqual(filter_result.filter.operations[1].operations[0].rightSide, "2")
+
+        self.assertIsInstance(filter_result.filter.operations[1].operations[1], CustomLiteralOperator)
+        self.assertEqual(filter_result.filter.operations[1].operations[1].propertyoperator, "fes:PropertyIsNotEqualTo")
+        self.assertEqual(filter_result.filter.operations[1].operations[1].leftSide, "1")
+        self.assertEqual(filter_result.filter.operations[1].operations[1].rightSide, "1")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This fixes cross-filtering on `<NULL>` values and closes #56 .

When selecting `<NULL>` / `N/A` in superset cross-filters, superset can generate SQL like:

```sql
sperrart IS NULL OR sperrart IN (NULL) AND (1 != 1)
```

Those patterns are valid SQL but partially not supported in WFS / Filter Encoding.

This PR now provides support for
- `OR` expressions
- left-hand side literals, e.g. `1 = 1`
- `IN (NULL)` handling, by replacing it with equivalent `1 = 2` condition

---

This also adds a little helper script for better isolated debugging. Through this, we can directly run a sql statement against a wfs url.
