### PR TITLE
feat: add oauth input fields and pass to dbapi

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ orjson>=3.11.4
 # Dependencies provided by superset, so we do not specify a version here
 flask_babel
 marshmallow
+apispec

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,7 @@ lxml>=5.4.0
 OWSLib>=0.34.0
 pyproj>=3.7.1
 orjson>=3.11.4
+
+# Dependencies provided by superset, so we do not specify a version here
+flask_babel
+marshmallow

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,9 @@ setup(
         "sqlalchemy.dialects": [
             "wfs = superset_wfs_dialect.dialect:WfsDialect",
         ],
+        "superset.db_engine_specs": [
+            "wfs = superset_wfs_dialect.engine_spec:WfsEngineSpec",
+        ],
     },
     python_requires=">=3.10",
 )

--- a/superset_wfs_dialect/base.py
+++ b/superset_wfs_dialect/base.py
@@ -115,11 +115,13 @@ class Connection:
         base_url="https://localhost/geoserver/ows",
         username=None,
         password=None,
+        oauth2_client=None,
         max_workers=5,
     ):
         self.base_url = base_url
         self.username = username
         self.password = password
+        self.oauth2_client= oauth2_client
         self.feature_type_schemas = {}
         self.server_info = {}
         self.wfs_output_format = None
@@ -1160,7 +1162,8 @@ def connect(*args, **kwargs):
     base_url = kwargs.get("base_url", "https://localhost/geoserver/ows")
     username = kwargs.get("username")
     password = kwargs.get("password")
-    return Connection(base_url=base_url, username=username, password=password)
+    oauth2_client = kwargs.get("oauth2_client")
+    return Connection(base_url=base_url, username=username, password=password, oauth2_client=oauth2_client)
 
 
 class FakeDbApi:

--- a/superset_wfs_dialect/dialect.py
+++ b/superset_wfs_dialect/dialect.py
@@ -30,6 +30,13 @@ class WfsDialect(DefaultDialect):
     supports_alter = False
     supports_unicode_statements = True
     supports_statement_cache = False
+    oauth2_client = None
+
+    def __init__(self, oauth2_client=None, **kwargs):
+        super().__init__(**kwargs)
+        if oauth2_client is not None:
+            self.oauth2_client = oauth2_client
+
 
     def create_connect_args(self, url):
         scheme = "https"
@@ -45,6 +52,8 @@ class WfsDialect(DefaultDialect):
         if username and password:
             connect_args["username"] = username
             connect_args["password"] = password
+        if self.oauth2_client is not None:
+            connect_args["oauth2_client"] = self.oauth2_client
 
         return [], connect_args
 

--- a/superset_wfs_dialect/engine_spec.py
+++ b/superset_wfs_dialect/engine_spec.py
@@ -1,0 +1,99 @@
+from typing import Any, TypedDict
+
+from flask_babel import gettext as __
+from marshmallow import fields, Schema
+from sqlalchemy.engine.url import URL
+
+from superset.databases.utils import make_url_safe
+from superset.db_engine_specs.base import BaseEngineSpec, BasicParametersMixin
+from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
+
+
+class WfsParametersSchema(Schema):
+    username = fields.String(
+        required=False, allow_none=True, metadata={"description": __("Username")}
+    )
+    password = fields.String(allow_none=True, metadata={"description": __("Password")})
+    host = fields.String(
+        required=True, metadata={"description": __("WFS URL")}
+    )
+
+
+class WfsParametersType(TypedDict, total=False):
+    username: str | None
+    password: str | None
+    host: str
+
+
+class WfsPropertiesType(TypedDict):
+    parameters: WfsParametersType
+
+
+class WfsParametersMixin(BasicParametersMixin):
+    default_driver = "wfs"
+    parameters_schema = WfsParametersSchema()
+
+
+class WfsEngineSpec(WfsParametersMixin, BaseEngineSpec):
+    engine = "wfs"
+    engine_name = "OGC WFS"
+    drivers = {"wfs": "OGC WFS"}
+
+    sqlalchemy_uri_placeholder = "[wfs|https]://host:port/path"
+    disable_ssh_tunneling = True
+    allows_joins = False
+    allows_subqueries = False
+    supports_file_upload = False
+    supports_dynamic_schema = False
+
+    @classmethod
+    def validate_parameters(
+        cls, properties: WfsPropertiesType
+    ) -> list[SupersetError]:
+        errors: list[SupersetError] = []
+
+        required = {"host"}
+        parameters = properties.get("parameters", {})
+        present = {key for key in parameters if parameters.get(key, ())}
+
+        if missing := sorted(required - present):
+            errors.append(
+                SupersetError(
+                    message=f'One or more parameters are missing: {", ".join(missing)}',
+                    error_type=SupersetErrorType.CONNECTION_MISSING_PARAMETERS_ERROR,
+                    level=ErrorLevel.WARNING,
+                    extra={"missing": missing},
+                ),
+            )
+
+        return errors
+
+    @classmethod
+    def build_sqlalchemy_uri(  # pylint: disable=unused-argument
+        cls,
+        parameters: WfsParametersType,
+        encrypted_extra: dict[str, str] | None = None,
+    ) -> str:
+        host = parameters["host"].replace("http://", "").replace("https://", "").replace("wfs://", "")
+
+        return str(
+            URL.create(
+                "wfs",
+                username=parameters.get("username"),
+                password=parameters.get("password"),
+                host=host,
+            )
+        )
+
+    @classmethod
+    def get_parameters_from_uri(  # pylint: disable=unused-argument
+        cls, uri: str, encrypted_extra: dict[str, Any] | None = None
+    ) -> WfsParametersType:
+        url = make_url_safe(uri)
+        cleaned_url = URL.create("wfs", host=url.host, database=url.database)
+
+        return {
+            "username": url.username,
+            "password": url.password,
+            "host": str(cleaned_url),
+        }

--- a/superset_wfs_dialect/engine_spec.py
+++ b/superset_wfs_dialect/engine_spec.py
@@ -1,12 +1,19 @@
 from typing import Any, TypedDict
 
+from apispec import APISpec
+from apispec.ext.marshmallow import MarshmallowPlugin
 from flask_babel import gettext as __
 from marshmallow import fields, Schema
 from sqlalchemy.engine.url import URL
 
 from superset.databases.utils import make_url_safe
+from superset.databases.schemas import encrypted_field_properties, EncryptedString
 from superset.db_engine_specs.base import BaseEngineSpec, BasicParametersMixin
 from superset.errors import ErrorLevel, SupersetError, SupersetErrorType
+
+from superset.models.core import Database
+
+ma_plugin = MarshmallowPlugin()
 
 
 class WfsParametersSchema(Schema):
@@ -17,12 +24,23 @@ class WfsParametersSchema(Schema):
     host = fields.String(
         required=True, metadata={"description": __("WFS URL")}
     )
+    # This will create the oauth2 form fields in the UI. However, data
+    # is passed back as `oauth2_client_info` in the encrypted_extra. So
+    # we have to be careful when to use which name.
+    oauth2_client = EncryptedString(
+        required=False,
+        metadata={
+            "description": __("OAuth2 client info"),
+            "field_name": "oauth2_client_info",
+        },
+    )
 
 
 class WfsParametersType(TypedDict, total=False):
     username: str | None
     password: str | None
     host: str
+    oauth2_client: str | None
 
 
 class WfsPropertiesType(TypedDict):
@@ -45,6 +63,8 @@ class WfsEngineSpec(WfsParametersMixin, BaseEngineSpec):
     allows_subqueries = False
     supports_file_upload = False
     supports_dynamic_schema = False
+
+    encrypted_extra_sensitive_fields: set[str] = {"$.oauth2_client_info.secret"}
 
     @classmethod
     def validate_parameters(
@@ -97,3 +117,37 @@ class WfsEngineSpec(WfsParametersMixin, BaseEngineSpec):
             "password": url.password,
             "host": str(cleaned_url),
         }
+
+    @staticmethod
+    def update_params_from_encrypted_extra(
+        database: Database,
+        params: dict[str, Any],
+    ) -> None:
+        """
+        Rename `oauth2_client_info` to `oauth2_client` to pass validation.
+        """
+        BaseEngineSpec.update_params_from_encrypted_extra(database, params)
+
+        if "oauth2_client_info" in params:
+            params["oauth2_client"] = params.pop("oauth2_client_info")
+
+
+    @classmethod
+    def parameters_json_schema(cls) -> Any:
+        """
+        Return configuration parameters as OpenAPI.
+        """
+        if not cls.parameters_schema:
+            return None
+
+        spec = APISpec(
+            title="Database Parameters",
+            version="1.0.0",
+            openapi_version="3.0.0",
+            plugins=[ma_plugin],
+        )
+
+        ma_plugin.init_spec(spec)
+        ma_plugin.converter.add_attribute_function(encrypted_field_properties)
+        spec.components.schema(cls.__name__, schema=cls.parameters_schema)
+        return spec.to_dict()["components"]["schemas"][cls.__name__]


### PR DESCRIPTION
This adds the oauth2 specific input fields to the mask. The related parameters will be passed to our dbapi implementation. However, they will not yet be used - this will be part of a separate PR.

<img width="508" height="858" alt="image" src="https://github.com/user-attachments/assets/af08003a-e6e9-400a-98ee-3b3818bca401" />

depends on https://github.com/terrestris/superset_wfs_dialect/pull/62