### PR TITLE
fix: url handling in host input field

### DIFF
--- a/superset_wfs_dialect/dialect.py
+++ b/superset_wfs_dialect/dialect.py
@@ -40,13 +40,11 @@ class WfsDialect(DefaultDialect):
 
     def create_connect_args(self, url):
         scheme = "https"
-        host = url.host
-        port = f":{url.port}" if url.port else ""
-        path = f"/{url.database}" if url.database else ""
         username = url.username
         password = url.password
 
-        base_url = f"{scheme}://{host}{port}{path}"
+        # create base_url from url but set the scheme to https
+        base_url = str(url.set(drivername=scheme))
 
         connect_args = {"base_url": base_url}
         if username and password:

--- a/superset_wfs_dialect/engine_spec.py
+++ b/superset_wfs_dialect/engine_spec.py
@@ -1,4 +1,5 @@
 from typing import Any, TypedDict
+from urllib.parse import urlparse, parse_qs
 
 from apispec import APISpec
 from apispec.ext.marshmallow import MarshmallowPlugin
@@ -94,14 +95,21 @@ class WfsEngineSpec(WfsParametersMixin, BaseEngineSpec):
         parameters: WfsParametersType,
         encrypted_extra: dict[str, str] | None = None,
     ) -> str:
-        host = parameters["host"].replace("http://", "").replace("https://", "").replace("wfs://", "")
+        raw = parameters["host"]
+        parsed = urlparse(raw)
+
+        ignored_query_keys = ["service", "version", "request"]
+        query = {k: v for k, v in parse_qs(parsed.query).items() if k.lower() not in ignored_query_keys}
 
         return str(
             URL.create(
                 "wfs",
                 username=parameters.get("username"),
                 password=parameters.get("password"),
-                host=host,
+                host=parsed.hostname,
+                port=parsed.port,
+                database=parsed.path.lstrip("/"),
+                query=query,
             )
         )
 
@@ -110,7 +118,13 @@ class WfsEngineSpec(WfsParametersMixin, BaseEngineSpec):
         cls, uri: str, encrypted_extra: dict[str, Any] | None = None
     ) -> WfsParametersType:
         url = make_url_safe(uri)
-        cleaned_url = URL.create("wfs", host=url.host, database=url.database)
+        cleaned_url = URL.create(
+                "https",
+                host=url.host,
+                port=url.port,
+                database=url.database,
+                query=url.query
+            )
 
         return {
             "username": url.username,

--- a/superset_wfs_dialect/tests/test_dialect.py
+++ b/superset_wfs_dialect/tests/test_dialect.py
@@ -15,6 +15,7 @@ class TestWfsDialect(unittest.TestCase):
         url.database = "testdb"
         url.username = "user"
         url.password = "pass"
+        url.set.return_value = "https://example.com:8080/testdb"
 
         expected_args = (
             [],


### PR DESCRIPTION
This improves the url handling by still showing the original url instead of the `wfs://` prefixed one. this also now properly handles ports and query parameters.

After saving and reopening the database dialog it now looks like this:

<img width="495" height="591" alt="image" src="https://github.com/user-attachments/assets/53e244d6-c3b0-4891-adad-26077d1852fd" />
